### PR TITLE
Workaround for failure to update version.h due to git branch name

### DIFF
--- a/examples/input.nn.recommended
+++ b/examples/input.nn.recommended
@@ -41,7 +41,8 @@ memorize_symfunc_results                       # Keep symmetry function results 
 test_fraction                   0.1            # Fraction of structures kept for testing.
 force_weight                    10.0           # Weight of force updates relative to energy updates.
 short_energy_fraction           1.000          # Fraction of energy updates per epoch.
-short_force_fraction            0.02315        # Fraction of force updates per epoch.
+#short_force_fraction            0.02315        # Fraction of force updates per epoch (not necessary if force_energy_ratio given).
+force_energy_ratio              10.0           # Specifies ratio between force and energy updates (ratio = updates_force / updates_energy).
 short_energy_error_threshold    0.00           # RMSE threshold for energy update candidates.
 short_force_error_threshold     1.00           # RMSE threshold for force update candidates.
 rmse_threshold_trials           3              # Maximum number of RMSE threshold trials.

--- a/src/libnnp/Settings.cpp
+++ b/src/libnnp/Settings.cpp
@@ -68,6 +68,7 @@ map<string, shared_ptr<Settings::Key>> const createKnownKeywordsMap()
     m["rmse_threshold_trials_charge"  ] = "";
     m["energy_fraction"               ] = "";
     m["force_fraction"                ] = "";
+    m["energy_force_ratio"            ] = "";
     m["charge_fraction"               ] = "";
     m["use_old_weights_short"         ] = "";
     m["use_old_weights_charge"        ] = "";

--- a/src/libnnp/Settings.cpp
+++ b/src/libnnp/Settings.cpp
@@ -68,7 +68,7 @@ map<string, shared_ptr<Settings::Key>> const createKnownKeywordsMap()
     m["rmse_threshold_trials_charge"  ] = "";
     m["energy_fraction"               ] = "";
     m["force_fraction"                ] = "";
-    m["energy_force_ratio"            ] = "";
+    m["force_energy_ratio"            ] = "";
     m["charge_fraction"               ] = "";
     m["use_old_weights_short"         ] = "";
     m["use_old_weights_charge"        ] = "";

--- a/src/libnnp/makefile
+++ b/src/libnnp/makefile
@@ -75,7 +75,7 @@ version:
 	@sed -i.bak -E "s/(N2P2_GIT_VERSION) .*/\1 \"$(GIT_VERSION)\"/" version.h
 	@$(eval GIT_REV = $(shell git rev-parse HEAD))
 	@sed -i.bak -E "s/(N2P2_GIT_REV) .*/\1 \"$(GIT_REV)\"/" version.h
-	@$(eval GIT_BRANCH = $(shell git rev-parse --abbrev-ref HEAD))
+	@$(eval GIT_BRANCH = $(subst /,_,$(shell git rev-parse --abbrev-ref HEAD)))
 	@sed -i.bak -E "s/(N2P2_GIT_BRANCH) .*/\1 \"$(GIT_BRANCH)\"/" version.h
 	@rm version.h.bak
 

--- a/src/libnnptrain/Training.cpp
+++ b/src/libnnptrain/Training.cpp
@@ -2874,21 +2874,21 @@ void Training::setupUpdatePlan(string const& property)
     // Actual property modified here.
     Property& pa = p[property];
     string keyword = property + "_fraction";
-    pa.epochFraction = atof(settings[keyword].c_str());
 
     // Override force fraction if keyword "energy_force_ratio" is provided.
     if (property == "force" &&
         p.exists("energy") &&
-        settings.keywordExists("energy_force_ratio"))
+        settings.keywordExists("force_energy_ratio"))
     {
-        double const ratio = atof(settings["energy_force_ratio"].c_str());
+        double const ratio = atof(settings["force_energy_ratio"].c_str());
         if (settings.keywordExists(keyword))
         {
             log << "WARNING: Given force fraction is ignored because "
-                   "energy/force ratio is provided.\n";
+                   "force/energy ratio is provided.\n";
         }
-        log << strpr("- Desired energy to force update ratio         : %.6f\n",
+        log << strpr("Desired force/energy update ratio              : %.6f\n",
                      ratio);
+        log << "----------------------------------------------\n";
         pa.epochFraction = (p["energy"].numTrainPatterns * ratio)
                          / p["force"].numTrainPatterns;
     }


### PR DESCRIPTION
Git branch names may contain the '/' character (the github CLI does this when checking out pull requests that have a branch name that clashes with a branch in the current repo) which breaks the sed command to update version.h and thus compilation fails. This PR substitutes all '/' characters with '_' in the git branch name and thus works around that issue.